### PR TITLE
Drag and Drop route items

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1762,6 +1762,11 @@
         "@types/react": "*"
       }
     },
+    "@types/sortablejs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.10.4.tgz",
+      "integrity": "sha512-iXdJUEM09Hc0RacStDvkEi5BBdHuuwdys0L5/GtsRiEht69Df4hapA3FwFIeXn2STicqJjBAkowyD1OA3jGgwA=="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -4179,6 +4184,14 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -6470,6 +6483,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -8235,6 +8256,11 @@
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
       }
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -10547,6 +10573,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
+      "integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10626,6 +10657,20 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz",
+      "integrity": "sha512-87It8sN0ineoC3nBW0SbQuTFXM6bUqM62uJGY4BtTf0yzPl8/3+bHMWkgIe0Z6m8e+gJgjWxefGRVfpE3VcdEg==",
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.1.1",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
       }
     },
     "react-bootstrap": {
@@ -10938,6 +10983,18 @@
         "warning": "^4.0.3"
       }
     },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",
@@ -10996,6 +11053,17 @@
         "webpack-dev-server": "3.10.3",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "4.3.1"
+      }
+    },
+    "react-sortablejs": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-2.0.11.tgz",
+      "integrity": "sha512-Id44yygU6H/fNRp0uWkGZnKGuBF8GF/Ts6gKX5NfwmzceRjH0e0XHsmBuQ6WXhBIVnMM+XgkEPub851mdti0TA==",
+      "requires": {
+        "@types/sortablejs": "^1.10.0",
+        "classnames": "^2.2.6",
+        "sortablejs": "1.10.1",
+        "tiny-invariant": "^1.0.6"
       }
     },
     "react-transition-group": {
@@ -11109,6 +11177,15 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -12190,6 +12267,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.1.tgz",
+      "integrity": "sha512-N6r7GrVmO8RW1rn0cTdvK3JR0BcqecAJ0PmYMCL3ZuqTH3pY+9QyqkmJSkkLyyDvd+AJnwaxTP22Ybr/83V9hQ=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -12672,6 +12754,11 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12963,6 +13050,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -13294,6 +13386,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-memo-one": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
+      "integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ=="
     },
     "util": {
       "version": "0.10.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,12 @@
     "load-google-maps-api": "^2.0.2",
     "prettier": "^2.0.5",
     "react": "^16.13.1",
+    "react-beautiful-dnd": "^13.0.0",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",
     "react-fontawesome": "^1.7.1",
     "react-scripts": "3.4.1",
+    "react-sortablejs": "^2.0.11",
     "serve": "^11.3.2",
     "stable": "^0.1.8"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,10 @@
-import React, { useState } from 'react';
-import Button from 'react-bootstrap/Button';
+import React from 'react';
 
 import RouteView from './RouteView.js';
 
 function App() {
-  const [text, setText] = useState('');
-
-  function handleClick() {
-    fetch('/api/v1/data')
-      .then((response) => response.text())
-      .then(setText);
-  }
-
   return (
     <div>
-      <Button onClick={handleClick} variant="secondary">
-        Click Me!
-      </Button>
-      <div>{text}</div>
       <RouteView />
     </div>
   );

--- a/frontend/src/RouteView.js
+++ b/frontend/src/RouteView.js
@@ -23,7 +23,7 @@ function RouteView() {
       </Row>
       <Row>
         <Col>
-          <Row className={styles.routeContainer}>
+          <Row className={styles.routeListContainer}>
             <Route places={MOCK_DATA} />
           </Row>
           <Row>

--- a/frontend/src/RouteView.module.css
+++ b/frontend/src/RouteView.module.css
@@ -1,3 +1,4 @@
-.routeContainer {
+.routeListContainer {
+  max-height: 1000px;
   overflow: auto;
 }

--- a/frontend/src/map/Map.js
+++ b/frontend/src/map/Map.js
@@ -18,6 +18,10 @@ function Map({ destinations, mode, centerLocation }) {
   const mapRef = useRef(null);
 
   useEffect(() => {
+    if (mode !== 'pins') {
+      return;
+    }
+    
     loadGoogleMapsApi({ key: 'AIzaSyDD_xK2HDMKPmDrsHndH5SAK9Jl-k5rHdg' }).then(
       (googleMaps) => {
         const map = new googleMaps.Map(mapRef.current, {

--- a/frontend/src/route/LocationCard.js
+++ b/frontend/src/route/LocationCard.js
@@ -17,7 +17,7 @@ import { Draggable } from 'react-beautiful-dnd';
  */
 function LocationCard({location, description, image, index}) {
   // ref: https://egghead.io/lessons/react-reorder-a-list-with-react-beautiful-dnd
-  return(
+  return (
     <Draggable draggableId={`draggable-${index}`} index={index}>
       {(provided) => 
         <Container className={styles.locationCardContainer}

--- a/frontend/src/route/LocationCard.js
+++ b/frontend/src/route/LocationCard.js
@@ -5,17 +5,18 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import styles from './LocationCard.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
-
+import { faSort } from '@fortawesome/free-solid-svg-icons';
 import { Draggable } from 'react-beautiful-dnd';
 
 /**
  * Return a card component representing a place the user has selected. 
- * @param location the name of the place selected
- * @param description a description of @param location
- * @param image image of @param location
+ * @param {string} location the name of the place selected
+ * @param {string} description a description of @param location
+ * @param {string} image image source of @param location
+ * @param {number} index index of location in route list
  */
 function LocationCard({location, description, image, index}) {
+  // ref: https://egghead.io/lessons/react-reorder-a-list-with-react-beautiful-dnd
   return(
     <Draggable draggableId={`draggable-${index}`} index={index}>
       {(provided) => 
@@ -37,13 +38,8 @@ function LocationCard({location, description, image, index}) {
                 </Card.ImgOverlay>
               </Card>
             </Col>
-            <Col xs={1} className={styles.arrows}>
-              <Row>
-                <FontAwesomeIcon icon={faAngleUp} className={styles.upArrow} />
-              </Row>
-              <Row>
-                <FontAwesomeIcon icon={faAngleDown} className={styles.downArrow} />
-              </Row>
+            <Col className={styles.arrows}>
+              <FontAwesomeIcon icon={faSort} />
             </Col>
           </Row>
         </Container>

--- a/frontend/src/route/LocationCard.js
+++ b/frontend/src/route/LocationCard.js
@@ -17,7 +17,7 @@ import { Draggable } from 'react-beautiful-dnd';
  */
 function LocationCard({location, description, image, index}) {
   return(
-    <Draggable draggableId={`drag-${index}`} index={index}>
+    <Draggable draggableId={`draggable-${index}`} index={index}>
       {(provided) => 
         <Container className={styles.locationCardContainer}
           {...provided.draggableProps}

--- a/frontend/src/route/LocationCard.js
+++ b/frontend/src/route/LocationCard.js
@@ -7,38 +7,48 @@ import styles from './LocationCard.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
 
+import { Draggable } from 'react-beautiful-dnd';
+
 /**
  * Return a card component representing a place the user has selected. 
  * @param location the name of the place selected
  * @param description a description of @param location
  * @param image image of @param location
  */
-function LocationCard({location, description, image}) {
+function LocationCard({location, description, image, index}) {
   return(
-    <Container className={styles.locationCardContainer}>
-      <Row>
-        <Col xs={11} className={styles.locationCard}>
-          <Card>
-            <Card.Img src={image} className={styles.locationImg} alt="Card image" />
-            <Card.ImgOverlay className={styles.overlay}></Card.ImgOverlay>
-            <Card.ImgOverlay className={styles.cardTxt}>
-              <Card.Title>{location}</Card.Title>
-              <Card.Text>
-                {description}
-              </Card.Text>
-            </Card.ImgOverlay>
-          </Card>
-        </Col>
-        <Col xs={1} className={styles.arrows}>
+    <Draggable draggableId={`drag-${index}`} index={index}>
+      {(provided) => 
+        <Container className={styles.locationCardContainer}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          ref={provided.innerRef}
+        >
           <Row>
-            <FontAwesomeIcon icon={faAngleUp} className={styles.upArrow} />
+            <Col xs={11} className={styles.locationCard}>
+              <Card>
+                <Card.Img src={image} className={styles.locationImg} alt="Card image" />
+                <Card.ImgOverlay className={styles.overlay}></Card.ImgOverlay>
+                <Card.ImgOverlay className={styles.cardTxt}>
+                  <Card.Title>{location}</Card.Title>
+                  <Card.Text>
+                    {description}
+                  </Card.Text>
+                </Card.ImgOverlay>
+              </Card>
+            </Col>
+            <Col xs={1} className={styles.arrows}>
+              <Row>
+                <FontAwesomeIcon icon={faAngleUp} className={styles.upArrow} />
+              </Row>
+              <Row>
+                <FontAwesomeIcon icon={faAngleDown} className={styles.downArrow} />
+              </Row>
+            </Col>
           </Row>
-          <Row>
-            <FontAwesomeIcon icon={faAngleDown} className={styles.downArrow} />
-          </Row>
-        </Col>
-      </Row>
-    </Container>
+        </Container>
+      }
+    </Draggable>
   );
 }
 

--- a/frontend/src/route/LocationCard.module.css
+++ b/frontend/src/route/LocationCard.module.css
@@ -22,16 +22,15 @@
 .arrows {
   color: #616161;
   font-size: 2rem;
-  margin: auto;
+  margin: auto 0;
+  padding: 0;
+  opacity: 0;
 }
 
-.upArrow,
-.downArrow {
+.locationCardContainer:hover .overlay {
   opacity: 0.5;
 }
 
-.upArrow:hover,
-.downArrow:hover {
-  cursor: pointer;
-  opacity: 1;
+.locationCardContainer:hover .arrows {
+  opacity: 0.6;
 }

--- a/frontend/src/route/Route.js
+++ b/frontend/src/route/Route.js
@@ -3,25 +3,45 @@ import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import LocationCard from './LocationCard.js';
 
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+
 /**
  * Return locations listed in order of the user's planned route.
  */
 function Route({places}) {
   // map data into list of location cards each representing a place the use selected
   const mockPlaces = places.map((place, index) => 
-    <Row key={index}>
-      <LocationCard 
-        location={place.location}
-        description={place.description}
-        image={place.image}
-      />
-    </Row>
+    <LocationCard 
+      location={place.location}
+      description={place.description}
+      image={place.image}
+      index={index}
+      key={index}
+    />
   );
 
+  function handleOnDragEnd() {
+    // TODO 
+  }
+
   return (
-    <Container>
-      {mockPlaces}
-    </Container>
+    <DragDropContext
+      onDragEnd={handleOnDragEnd}
+    >
+      <Droppable droppableId="route-list">
+        {provided => {
+          console.log(provided)
+          return (
+          <div
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+          >
+            {mockPlaces}
+            {provided.placeholder}
+          </div>)
+        }}
+      </Droppable>
+    </DragDropContext>
   );
 }
 

--- a/frontend/src/route/Route.js
+++ b/frontend/src/route/Route.js
@@ -1,8 +1,5 @@
-import React from 'react';
-import Container from 'react-bootstrap/Container';
-import Row from 'react-bootstrap/Row';
+import React, { useState } from 'react';
 import LocationCard from './LocationCard.js';
-
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 
 /**
@@ -10,18 +7,26 @@ import { DragDropContext, Droppable } from 'react-beautiful-dnd';
  */
 function Route({places}) {
   // map data into list of location cards each representing a place the use selected
-  const mockPlaces = places.map((place, index) => 
-    <LocationCard 
-      location={place.location}
-      description={place.description}
-      image={place.image}
-      index={index}
-      key={index}
-    />
-  );
+  const [placesList, setPlacesList] = useState(places);
 
-  function handleOnDragEnd() {
-    // TODO 
+  // referece: https://egghead.io/lessons/react-persist-list-reordering-with-react-beautiful-dnd-using-the-ondragend-callback
+  function handleOnDragEnd(result) {
+    const {destination, source, draggableId } = result;
+
+    // no change in list ordering due after drag
+    if (!destination) {
+      return;
+    }
+
+    // item dropped in same place it started in (no change in list ordering)
+    if (destination.droppableId === source.droppableId && destination.index === source.index) {
+      return;
+    }
+
+    const newPlacesList = Array.from(placesList);
+    newPlacesList.splice(source.index, 1);
+    newPlacesList.splice(destination.index, 0, placesList[source.index]);
+    setPlacesList(newPlacesList);
   }
 
   return (
@@ -29,17 +34,23 @@ function Route({places}) {
       onDragEnd={handleOnDragEnd}
     >
       <Droppable droppableId="route-list">
-        {provided => {
-          console.log(provided)
-          return (
+        {provided => 
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
           >
-            {mockPlaces}
+            {placesList.map((place, index) => 
+              <LocationCard 
+                location={place.location}
+                description={place.description}
+                image={place.image}
+                index={index}
+                key={index}
+              />
+            )}
             {provided.placeholder}
-          </div>)
-        }}
+          </div>
+        }
       </Droppable>
     </DragDropContext>
   );

--- a/frontend/src/route/Route.js
+++ b/frontend/src/route/Route.js
@@ -3,7 +3,8 @@ import LocationCard from './LocationCard.js';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 
 /**
- * Return locations listed in order of the user's planned route.
+ * Return locations listed in order of the user's planned route. 
+ * Route list is customizable via drag and drop (docs: https://github.com/atlassian/react-beautiful-dnd)
  */
 function Route({places}) {
   // map data into list of location cards each representing a place the use selected
@@ -29,6 +30,7 @@ function Route({places}) {
     setPlacesList(newPlacesList);
   }
 
+  // ref: https://egghead.io/lessons/react-reorder-a-list-with-react-beautiful-dnd
   return (
     <DragDropContext
       onDragEnd={handleOnDragEnd}

--- a/frontend/src/route/Route.js
+++ b/frontend/src/route/Route.js
@@ -6,13 +6,13 @@ import { DragDropContext, Droppable } from 'react-beautiful-dnd';
  * Return locations listed in order of the user's planned route. 
  * Route list is customizable via drag and drop (docs: https://github.com/atlassian/react-beautiful-dnd)
  */
-function Route({places}) {
+function Route({places: initialPlaces}) {
   // map data into list of location cards each representing a place the use selected
-  const [placesList, setPlacesList] = useState(places);
+  const [places, setPlaces] = useState(initialPlaces);
 
   // referece: https://egghead.io/lessons/react-persist-list-reordering-with-react-beautiful-dnd-using-the-ondragend-callback
-  function handleOnDragEnd(result) {
-    const {destination, source, draggableId } = result;
+  function handleOnDragEnd({destination, source, draggableId}) {
+    // const  = result;
 
     // no change in list ordering due after drag
     if (!destination) {
@@ -24,24 +24,22 @@ function Route({places}) {
       return;
     }
 
-    const newPlacesList = Array.from(placesList);
-    newPlacesList.splice(source.index, 1);
-    newPlacesList.splice(destination.index, 0, placesList[source.index]);
-    setPlacesList(newPlacesList);
+    const newPlaces = Array.from(places);
+    newPlaces.splice(source.index, 1);
+    newPlaces.splice(destination.index, 0, places[source.index]);
+    setPlaces(newPlaces);
   }
 
   // ref: https://egghead.io/lessons/react-reorder-a-list-with-react-beautiful-dnd
   return (
-    <DragDropContext
-      onDragEnd={handleOnDragEnd}
-    >
+    <DragDropContext onDragEnd={handleOnDragEnd}>
       <Droppable droppableId="route-list">
         {provided => 
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
           >
-            {placesList.map((place, index) => 
+            {places.map((place, index) => 
               <LocationCard 
                 location={place.location}
                 description={place.description}

--- a/frontend/src/route/mockData.js
+++ b/frontend/src/route/mockData.js
@@ -23,4 +23,19 @@ export const /** !Array<Place> */ MOCK_DATA = [
       description: 'Description of location if we want to include it here.',
       image: testImg,
     },
+    {
+      location: 'Duplicate 3',
+      description: 'Description of location if we want to include it here.',
+      image: testImg,
+    },
+    {
+      location: 'Duplicate 4',
+      description: 'Description of location if we want to include it here.',
+      image: testImg,
+    },
+    {
+      location: 'Duplicate 5',
+      description: 'Description of location if we want to include it here.',
+      image: testImg,
+    },
   ];


### PR DESCRIPTION
Use [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd) to drag and drop cards in the route list to customize order. 

- fix height of route list, overflow is scrollable
- follow [this](https://egghead.io/lessons/react-reorder-a-list-with-react-beautiful-dnd) tutorial to implement drag/drop 
  - define entire `Route` component, which is the list of location cards as both the DragDropContext (See diagram at bottom for explanation of components) and Droppable
  - define each location card as Draggable
- follow [this](https://egghead.io/lessons/react-persist-list-reordering-with-react-beautiful-dnd-using-the-ondragend-callback) tutorial to persist the ordering of location cards after user has dragged a card 
  - in `handleOnDragEnd` in `Route.js`, create a duplicate of the original `placesList`, rearrange the ordering of places in that duplicate, then `setPlacesList` to that mutated duplicate
  - moved mapping of `placesList` to the return statement and made `placesList` a state so that a new list will be rendered every time the ordering changes
- minor CSS changes
  - on hover, overlay opacity increases
  - on hover, sort icon appears

On hover (mission peak):
![image](https://user-images.githubusercontent.com/19807230/86062107-d7c3b780-ba1c-11ea-8136-8a58fbaa4565.png)

Mid-drag:
![image](https://user-images.githubusercontent.com/19807230/86062144-e7430080-ba1c-11ea-9774-d53fe839516d.png)

reference react-dnd DragDropContext diagram:
![image](https://user-images.githubusercontent.com/19807230/86062492-abf50180-ba1d-11ea-93f9-ac87041ed868.png)

