### PR TITLE
Format Java files in /test directory and subdirectories

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ jobs:
       run: node_modules/prettier/bin-prettier.js -c 'frontend/src/**/*.js'
     - name: Check Java Formatting
       if: always()
+      # See https://stackoverflow.com/a/21282167
       run: diff -u <(find . -type f -name *.java -exec cat {} \;) <(find . -type f -name *.java -exec node_modules/clang-format/bin/linux_x64/clang-format --style=Google {} \;)
     - name: Notify on failure
       if: failure()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       run: node_modules/prettier/bin-prettier.js -c 'frontend/src/**/*.js'
     - name: Check Java Formatting
       if: always()
-      run: diff -u <(cat backend/src/main/java/com/google/sps/servlets/*.java) <(node_modules/clang-format/bin/linux_x64/clang-format --style=Google backend/src/main/java/com/google/sps/servlets/*.java)
+      run: diff -u <(find . -type f -name *.java -exec cat {} \;) <(find . -type f -name *.java -exec node_modules/clang-format/bin/linux_x64/clang-format --style=Google {} \;)
     - name: Notify on failure
       if: failure()
       run: echo 'run "make validate" and "make pretty" to see/fix errors locally'

--- a/backend/src/main/java/com/google/sps/servlets/OptimizeServlet.java
+++ b/backend/src/main/java/com/google/sps/servlets/OptimizeServlet.java
@@ -28,21 +28,21 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/optimize")
 public class OptimizeServlet extends HttpServlet {
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException { 
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     try {
       // call Distance Matrix API
       GeoApiContext context =
           new GeoApiContext.Builder().apiKey("AIzaSyDD_xK2HDMKPmDrsHndH5SAK9Jl-k5rHdg").build();
       String[] origins = new String[] {"Vancouver BC", "Seattle"};
       String[] destinations = new String[] {"San Francisco", "Victoria BC"};
-      DistanceMatrixApiRequest req = DistanceMatrixApi.newRequest(context); 
+      DistanceMatrixApiRequest req = DistanceMatrixApi.newRequest(context);
       DistanceMatrix result = req.origins(origins).destinations(destinations).await();
 
       for (int i = 0; i < origins.length; i++) {
         for (int j = 0; j < destinations.length; j++) {
           long distance = result.rows[i].elements[j].distance.inMeters;
         }
-      } 
+      }
     } catch (Exception e) {
       System.out.println(e);
     }

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ node_modules:
 pretty: node_modules
 	$(PRETTIER) --write 'frontend/src/**/*.css'
 	$(PRETTIER) --write 'frontend/src/**/*.js'
-	find backend/src/main -iname *.java | xargs $(CLANG_FORMAT) -i
+	find backend/src -iname *.java | xargs $(CLANG_FORMAT) -i
 
 validate: node_modules
 	$(ESLINT) 'frontend/src/**/*.js'


### PR DESCRIPTION
As previously mentioned, adding formatter to run on Java files in subdirectories including those in backend/src/test/...

Tested locally, `make pretty` formatted java files in subdirectories and for the yaml file, I just ran the command that will run on github
![image](https://user-images.githubusercontent.com/22455214/86966955-f110e600-c137-11ea-9c4f-4a5ec074216a.png)

checks on github caught this
https://github.com/googleinterns/step88-2020/pull/103/checks?check_run_id=851425615
![image](https://user-images.githubusercontent.com/22455214/86967425-9c219f80-c138-11ea-823b-7888f99d94cf.png)

