### PR TITLE
Dfs Alg

### DIFF
--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -95,8 +95,32 @@ public final class TspOptimizer {
     return mst;
   }
 
-  // Visible for testing
+  /**
+   * Return list of attractions in pre-order DFS traversal order.
+   * @param source the vertex on which to start DFS
+   * @param graph the MST on which to run DFS
+   */
   static ArrayList<Attraction> dfs(Attraction source, HashMap<Attraction, ArrayList<Edge>> graph) {
-    return null;
+    return dfsHelper(source, graph, new HashSet<>());
+  }
+
+  /**
+   * Helper function for dfs.
+   * @param curr the vertex that is currently being visited in the DFS traversal
+   * @param graph the MST on which to run DFS
+   * @param visited set of visited vertices
+   */
+  private static ArrayList<Attraction> dfsHelper(
+      Attraction curr, HashMap<Attraction, ArrayList<Edge>> graph, HashSet<Attraction> visited) {
+    ArrayList<Attraction> dfsOrdering = new ArrayList<>();
+    dfsOrdering.add(curr);
+    visited.add(curr);
+    for (Edge e : graph.get(curr)) {
+      Attraction neighbor = e.getOtherEndpoint(curr);
+      if (!visited.contains(neighbor)) {
+        dfsOrdering.addAll(dfsHelper(neighbor, graph, visited));
+      }
+    }
+    return dfsOrdering;
   }
 }

--- a/backend/src/test/java/com/google/sps/TspOptimizerTest.java
+++ b/backend/src/test/java/com/google/sps/TspOptimizerTest.java
@@ -38,7 +38,7 @@ public final class TspOptimizerTest {
   // Straight forward triangle graph
   private static final HashMap<Attraction, ArrayList<Edge>> TRIANGLE = create_TRIANGLE();
   private static final HashMap<Attraction, ArrayList<Edge>> TRIANGLE_MST = create_TRIANGLE_MST();
-  
+
   // Complete graph with 4 vertices that has a single optimal solution
   private static final HashMap<Attraction, ArrayList<Edge>> K4 = create_K4();
   private static final HashMap<Attraction, ArrayList<Edge>> K4_MST = create_K4_MST();
@@ -76,14 +76,23 @@ public final class TspOptimizerTest {
   }
 
   @Test
-  @Ignore
-  public void dfs_TRIANGLE() {
-    // Generate the MST of the TRIANGLE graph
+  public void dfs_TRIANGLE_MST() {
+    // Generate the dfs ordering of TRIANGLE_MST graph
 
     ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(A, B, C));
     ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(A, C, B));
     ArrayList<Attraction> actual = TspOptimizer.dfs(A, TRIANGLE_MST);
     Assert.assertTrue(expected1.equals(actual) || expected2.equals(actual));
+  }
+
+  @Test
+  public void K4_TRIANGLE_MST() {
+    // Generate the dfs ordering of K4_MST graph.
+    // Start at vertex A so there is a unique DFS traversal.
+
+    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C, D));
+    ArrayList<Attraction> actual = TspOptimizer.dfs(A, K4_MST);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/backend/src/test/java/com/google/sps/TspOptimizerTest.java
+++ b/backend/src/test/java/com/google/sps/TspOptimizerTest.java
@@ -86,7 +86,7 @@ public final class TspOptimizerTest {
   }
 
   @Test
-  public void K4_TRIANGLE_MST() {
+  public void dfs_K4_MST() {
     // Generate the dfs ordering of K4_MST graph.
     // Start at vertex A so there is a unique DFS traversal.
 


### PR DESCRIPTION
Implement `dfs` function, which returns an arraylist of `Attraction`s in the order of the dfs traversal of the graph's mst. 

- Include helper function `dfsHelper`
  - recursively called to visit all vertices depth first
  - maintains `visited` set to keep track of all visited vertices 
- add `dfs` tests on `TRIANGLE` and `K4` graphs