### PR TITLE
Tsp optimization alg

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -21,7 +21,8 @@ import java.util.PriorityQueue;
 
 public final class TspOptimizer {
   /**
-   * Call optimize(source, graph) after determining a source Attraction from which to run MST algorithm.
+   * Call optimize(source, graph) after determining a source Attraction from which to run MST
+   * algorithm.
    * @return list of attractions in optimal visiting order
    */
   public static ArrayList<Attraction> optimize(HashMap<Attraction, ArrayList<Edge>> graph) {
@@ -47,7 +48,8 @@ public final class TspOptimizer {
    * @param graph the mst that contains the attractions and that was dfs traversed
    * @return arraylist containing the attractions in optimized order
    */
-  private static ArrayList<Attraction> getOptimalOrdering(ArrayList<Attraction> attractions, HashMap<Attraction, ArrayList<Edge>> graph) {
+  private static ArrayList<Attraction> getOptimalOrdering(
+      ArrayList<Attraction> attractions, HashMap<Attraction, ArrayList<Edge>> graph) {
     // determine heaviest edge
     long maxDistance = 0;
     int startIndex = 0;
@@ -64,7 +66,8 @@ public final class TspOptimizer {
     }
 
     // create optimized ordering
-    ArrayList<Attraction> optimizedOrder = new ArrayList<>(attractions.subList(startIndex, attractions.size()));
+    ArrayList<Attraction> optimizedOrder =
+        new ArrayList<>(attractions.subList(startIndex, attractions.size()));
     optimizedOrder.addAll(attractions.subList(0, startIndex));
     return optimizedOrder;
   }

--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -17,6 +17,7 @@ package com.google.sps;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.PriorityQueue;
 
 public final class TspOptimizer {
@@ -26,7 +27,7 @@ public final class TspOptimizer {
    * @param graph the graph on which to find an optimal path between all attractions
    * @return list of attractions in optimal visiting order
    */
-  public static ArrayList<Attraction> optimize(HashMap<Attraction, ArrayList<Edge>> graph) {
+  public static List<Attraction> optimize(HashMap<Attraction, ArrayList<Edge>> graph) {
     Attraction source = graph.keySet().iterator().next();
     return optimize(source, graph);
   }
@@ -37,7 +38,7 @@ public final class TspOptimizer {
    * @param graph the graph on which to find an optimal path between all attractions
    * @return list of attractions in optimal visiting order
    */
-  public static ArrayList<Attraction> optimize(
+  public static List<Attraction> optimize(
       Attraction source, HashMap<Attraction, ArrayList<Edge>> graph) {
     HashMap<Attraction, ArrayList<Edge>> mst = getMst(source, graph);
     ArrayList<Attraction> dfsOrder = dfs(source, mst);
@@ -50,8 +51,8 @@ public final class TspOptimizer {
    * @param graph the mst that contains the attractions and that was dfs traversed
    * @return arraylist containing the attractions in optimized order
    */
-  private static ArrayList<Attraction> getOptimalOrdering(
-      ArrayList<Attraction> attractions, HashMap<Attraction, ArrayList<Edge>> graph) {
+  private static List<Attraction> getOptimalOrdering(
+      List<Attraction> attractions, HashMap<Attraction, ArrayList<Edge>> graph) {
     // determine heaviest edge
     long maxDistance = 0;
     int startIndex = 0;
@@ -68,8 +69,7 @@ public final class TspOptimizer {
     }
 
     // create optimized ordering
-    ArrayList<Attraction> optimizedOrder =
-        new ArrayList<>(attractions.subList(startIndex, attractions.size()));
+    List<Attraction> optimizedOrder = attractions.subList(startIndex, attractions.size());
     optimizedOrder.addAll(attractions.subList(0, startIndex));
     return optimizedOrder;
   }

--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -23,6 +23,7 @@ public final class TspOptimizer {
   /**
    * Call optimize(source, graph) after determining a source Attraction from which to run MST
    * algorithm.
+   * @param graph the graph on which to find an optimal path between all attractions
    * @return list of attractions in optimal visiting order
    */
   public static ArrayList<Attraction> optimize(HashMap<Attraction, ArrayList<Edge>> graph) {
@@ -33,6 +34,7 @@ public final class TspOptimizer {
   /**
    * Run TSP approximation algorithm.
    * @param source the source Attraction from which to run MST algorithm
+   * @param graph the graph on which to find an optimal path between all attractions
    * @return list of attractions in optimal visiting order
    */
   public static ArrayList<Attraction> optimize(
@@ -129,6 +131,7 @@ public final class TspOptimizer {
    * Return list of attractions in pre-order DFS traversal order.
    * @param source the vertex on which to start DFS
    * @param graph the MST on which to run DFS
+   * @return list of attractions in DFS order
    */
   static ArrayList<Attraction> dfs(Attraction source, HashMap<Attraction, ArrayList<Edge>> graph) {
     return dfsHelper(source, graph, new HashSet<>());
@@ -139,6 +142,7 @@ public final class TspOptimizer {
    * @param curr the vertex that is currently being visited in the DFS traversal
    * @param graph the MST on which to run DFS
    * @param visited set of visited vertices
+   * @return list of arractions in DFS order
    */
   private static ArrayList<Attraction> dfsHelper(
       Attraction curr, HashMap<Attraction, ArrayList<Edge>> graph, HashSet<Attraction> visited) {

--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -21,7 +21,7 @@ import java.util.PriorityQueue;
 
 public final class TspOptimizer {
   /**
-   * Call optimize(source) after determining a source Attraction from which to run MST algorithm.
+   * Call optimize(source, graph) after determining a source Attraction from which to run MST algorithm.
    * @return list of attractions in optimal visiting order
    */
   public static ArrayList<Attraction> optimize(HashMap<Attraction, ArrayList<Edge>> graph) {
@@ -38,7 +38,7 @@ public final class TspOptimizer {
       Attraction source, HashMap<Attraction, ArrayList<Edge>> graph) {
     HashMap<Attraction, ArrayList<Edge>> mst = getMst(source, graph);
     ArrayList<Attraction> dfsOrder = dfs(source, mst);
-    return getOptimalOrdering(dfsOrder, mst);
+    return getOptimalOrdering(dfsOrder, graph);
   }
 
   /**
@@ -50,7 +50,6 @@ public final class TspOptimizer {
   private static ArrayList<Attraction> getOptimalOrdering(ArrayList<Attraction> attractions, HashMap<Attraction, ArrayList<Edge>> graph) {
     // determine heaviest edge
     long maxDistance = 0;
-    Edge maxEdge = null;
     int startIndex = 0;
     for (int i = 0; i < attractions.size(); i++) {
       Attraction curr = attractions.get(i);

--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -25,11 +25,8 @@ public final class TspOptimizer {
    * @return list of attractions in optimal visiting order
    */
   public static ArrayList<Attraction> optimize(HashMap<Attraction, ArrayList<Edge>> graph) {
-    ArrayList<Attraction> optimizedOrder = new ArrayList<>();
-    for (Attraction a : graph.keySet()) {
-      optimizedOrder.add(a);
-    }
-    return optimizedOrder;
+    Attraction source = graph.keySet().iterator().next();
+    return optimize(source, graph);
   }
 
   /**
@@ -39,7 +36,38 @@ public final class TspOptimizer {
    */
   public static ArrayList<Attraction> optimize(
       Attraction source, HashMap<Attraction, ArrayList<Edge>> graph) {
-    return null;
+    HashMap<Attraction, ArrayList<Edge>> mst = getMst(source, graph);
+    ArrayList<Attraction> dfsOrder = dfs(source, mst);
+    return getOptimalOrdering(dfsOrder, mst);
+  }
+
+  /**
+   * Remove the heaviest edge from the dfs ordering to produce an optimized ordering
+   * @param attractions list of attractions in dfs ordering
+   * @param graph the mst that contains the attractions and that was dfs traversed
+   * @return arraylist containing the attractions in optimized order
+   */
+  private static ArrayList<Attraction> getOptimalOrdering(ArrayList<Attraction> attractions, HashMap<Attraction, ArrayList<Edge>> graph) {
+    // determine heaviest edge
+    long maxDistance = 0;
+    Edge maxEdge = null;
+    int startIndex = 0;
+    for (int i = 0; i < attractions.size(); i++) {
+      Attraction curr = attractions.get(i);
+      int nextIndex = (i + 1) % attractions.size();
+      Attraction next = attractions.get(nextIndex);
+      for (Edge e : graph.get(curr)) {
+        if (e.getOtherEndpoint(curr).equals(next)) {
+          maxDistance = Math.max(e.getDistance(), maxDistance);
+          startIndex = e.getDistance() == maxDistance ? nextIndex : startIndex;
+        }
+      }
+    }
+
+    // create optimized ordering
+    ArrayList<Attraction> optimizedOrder = new ArrayList<>(attractions.subList(startIndex, attractions.size()));
+    optimizedOrder.addAll(attractions.subList(0, startIndex));
+    return optimizedOrder;
   }
 
   /**

--- a/backend/src/main/java/com/google/sps/TspOptimizer.java
+++ b/backend/src/main/java/com/google/sps/TspOptimizer.java
@@ -95,8 +95,32 @@ public final class TspOptimizer {
     return mst;
   }
 
-  // Visible for testing
+  /**
+   * Return list of attractions in pre-order DFS traversal order.
+   * @param source the vertex on which to start DFS
+   * @param graph the MST on which to run DFS
+   */
   static ArrayList<Attraction> dfs(Attraction source, HashMap<Attraction, ArrayList<Edge>> graph) {
-    return null;
+    return dfsHelper(source, graph, new HashSet<>());
+  }
+
+  /**
+   * Helper function for dfs.
+   * @param curr the vertex that is currently being visited in the DFS traversal
+   * @param graph the MST on which to run DFS
+   * @param visited set of visited vertices
+   */
+  private static ArrayList<Attraction> dfsHelper(
+      Attraction curr, HashMap<Attraction, ArrayList<Edge>> graph, HashSet<Attraction> visited) {
+    ArrayList<Attraction> dfsOrdering = new ArrayList<>();
+    dfsOrdering.add(curr);
+    visited.add(curr);
+    for (Edge e : graph.get(curr)) {
+      Attraction neighbor = e.getOtherEndpoint(curr);
+      if (!visited.contains(neighbor)) {
+        dfsOrdering.addAll(dfsHelper(neighbor, graph, visited));
+      }
+    }
+    return dfsOrdering;
   }
 }

--- a/backend/src/main/java/com/google/sps/servlets/OptimizeServlet.java
+++ b/backend/src/main/java/com/google/sps/servlets/OptimizeServlet.java
@@ -25,6 +25,7 @@ import com.google.sps.TspOptimizer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -42,7 +43,7 @@ public class OptimizeServlet extends HttpServlet {
     String body = IOUtils.toString(request.getReader());
     Gson g = new Gson();
     JSON json = g.fromJson(body, JSON.class);
-    ArrayList<Attraction> attractions = json.attractions;
+    List<Attraction> attractions = json.attractions;
 
     // call Distance Matrix API
     String[] attractionNames =
@@ -66,7 +67,7 @@ public class OptimizeServlet extends HttpServlet {
     }
 
     // call TSP approximation algorithm
-    ArrayList<Attraction> optimizedOrder = TspOptimizer.optimize(graph);
+    List<Attraction> optimizedOrder = TspOptimizer.optimize(graph);
 
     String optimizedOrderJSON = g.toJson(optimizedOrder);
     response.setContentType("json;");
@@ -83,9 +84,9 @@ public class OptimizeServlet extends HttpServlet {
   }
 
   private class JSON {
-    private ArrayList<Attraction> attractions;
+    private List<Attraction> attractions;
 
-    private JSON(ArrayList<Attraction> attractions) {
+    private JSON(List<Attraction> attractions) {
       this.attractions = attractions;
     }
   }

--- a/backend/src/test/java/com/google/sps/TspOptimizerTest.java
+++ b/backend/src/test/java/com/google/sps/TspOptimizerTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -82,9 +83,9 @@ public final class TspOptimizerTest {
   public void dfs_TRIANGLE_MST() {
     // Generate the dfs ordering of TRIANGLE_MST graph
 
-    ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(A, B, C));
-    ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(A, C, B));
-    ArrayList<Attraction> actual = TspOptimizer.dfs(A, TRIANGLE_MST);
+    List<Attraction> expected1 = Arrays.asList(A, B, C);
+    List<Attraction> expected2 = Arrays.asList(A, C, B);
+    List<Attraction> actual = TspOptimizer.dfs(A, TRIANGLE_MST);
     assertThat(Arrays.asList(expected1, expected2), hasItem(actual));
   }
 
@@ -93,8 +94,8 @@ public final class TspOptimizerTest {
     // Generate the dfs ordering of K4_MST graph.
     // Start at vertex A so there is a unique DFS traversal.
 
-    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C, D));
-    ArrayList<Attraction> actual = TspOptimizer.dfs(A, K4_MST);
+    List<Attraction> expected = Arrays.asList(A, B, C, D);
+    List<Attraction> actual = TspOptimizer.dfs(A, K4_MST);
     Assert.assertEquals(expected, actual);
   }
 
@@ -103,9 +104,9 @@ public final class TspOptimizerTest {
     // Use triangle graph. Choose a random Attraction as source.
     // Algorithm should return a path with the two shortest edges B--A--C or C--A--B.
 
-    ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(B, A, C));
-    ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(C, A, B));
-    ArrayList<Attraction> actual = TspOptimizer.optimize(TRIANGLE);
+    List<Attraction> expected1 = Arrays.asList(B, A, C);
+    List<Attraction> expected2 = Arrays.asList(C, A, B);
+    List<Attraction> actual = TspOptimizer.optimize(TRIANGLE);
     assertThat(Arrays.asList(expected1, expected2), hasItem(actual));
   }
 
@@ -114,8 +115,8 @@ public final class TspOptimizerTest {
     // Use triangle graph. DFS traversal of MST is the optimal path.
     // Algorithm should return a path with the two shortest edges B--A--C.
 
-    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(B, A, C));
-    ArrayList<Attraction> actual = TspOptimizer.optimize(B, TRIANGLE);
+    List<Attraction> expected = Arrays.asList(B, A, C);
+    List<Attraction> actual = TspOptimizer.optimize(B, TRIANGLE);
     Assert.assertEquals(expected, actual);
   }
 
@@ -125,9 +126,9 @@ public final class TspOptimizerTest {
     // deletion of heaviest edge in cycle. Algorithm should return a path with the two shortest
     // edges B--A--C or C--A--B.
 
-    ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(B, A, C));
-    ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(C, A, B));
-    ArrayList<Attraction> actual = TspOptimizer.optimize(A, TRIANGLE);
+    List<Attraction> expected1 = Arrays.asList(B, A, C);
+    List<Attraction> expected2 = Arrays.asList(C, A, B);
+    List<Attraction> actual = TspOptimizer.optimize(A, TRIANGLE);
     assertThat(Arrays.asList(expected1, expected2), hasItem(actual));
   }
 
@@ -136,8 +137,8 @@ public final class TspOptimizerTest {
     // Create complete graph with 4 vertices. DFS traversal of MST is the optimal path.
     // Algorithm should return a path with three shortest edges A--B--C--D.
 
-    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C, D));
-    ArrayList<Attraction> actual = TspOptimizer.optimize(A, K4);
+    List<Attraction> expected = Arrays.asList(A, B, C, D);
+    List<Attraction> actual = TspOptimizer.optimize(A, K4);
     Assert.assertEquals(expected, actual);
   }
 
@@ -147,11 +148,11 @@ public final class TspOptimizerTest {
     // Algorithm should return a path 6/5 times length of optimal path C--D--B--A
     // or the optimal path A--B--C--D.
 
-    ArrayList<Attraction> expectedOptimal1 = new ArrayList<>(Arrays.asList(A, B, C, D));
-    ArrayList<Attraction> expectedOptimal2 = new ArrayList<>(Arrays.asList(D, C, B, A));
-    ArrayList<Attraction> expectedSuboptimal1 = new ArrayList<>(Arrays.asList(C, D, B, A));
-    ArrayList<Attraction> expectedSuboptimal2 = new ArrayList<>(Arrays.asList(A, B, D, C));
-    ArrayList<Attraction> actual = TspOptimizer.optimize(C, K4);
+    List<Attraction> expectedOptimal1 = Arrays.asList(A, B, C, D);
+    List<Attraction> expectedOptimal2 = Arrays.asList(D, C, B, A);
+    List<Attraction> expectedSuboptimal1 = Arrays.asList(C, D, B, A);
+    List<Attraction> expectedSuboptimal2 = Arrays.asList(A, B, D, C);
+    List<Attraction> actual = TspOptimizer.optimize(C, K4);
     assertThat(
         Arrays.asList(expectedOptimal1, expectedOptimal2, expectedSuboptimal1, expectedSuboptimal2),
         hasItem(actual));

--- a/backend/src/test/java/com/google/sps/TspOptimizerTest.java
+++ b/backend/src/test/java/com/google/sps/TspOptimizerTest.java
@@ -14,6 +14,9 @@
 
 package com.google.sps;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,8 +26,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 @RunWith(JUnit4.class)
 public final class TspOptimizerTest {
@@ -151,7 +152,9 @@ public final class TspOptimizerTest {
     ArrayList<Attraction> expectedSuboptimal1 = new ArrayList<>(Arrays.asList(C, D, B, A));
     ArrayList<Attraction> expectedSuboptimal2 = new ArrayList<>(Arrays.asList(A, B, D, C));
     ArrayList<Attraction> actual = TspOptimizer.optimize(C, K4);
-    assertThat(Arrays.asList(expectedOptimal1, expectedOptimal2, expectedSuboptimal1, expectedSuboptimal2), hasItem(actual));
+    assertThat(
+        Arrays.asList(expectedOptimal1, expectedOptimal2, expectedSuboptimal1, expectedSuboptimal2),
+        hasItem(actual));
   }
 
   private void assertGraphEquals(

--- a/backend/src/test/java/com/google/sps/TspOptimizerTest.java
+++ b/backend/src/test/java/com/google/sps/TspOptimizerTest.java
@@ -23,6 +23,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 
 @RunWith(JUnit4.class)
 public final class TspOptimizerTest {
@@ -48,7 +50,7 @@ public final class TspOptimizerTest {
     // Generate the MST of the TRIANGLE graph starting at vertex A
 
     HashMap<Attraction, ArrayList<Edge>> actual = TspOptimizer.getMst(A, TRIANGLE);
-    checkGraphEquals(TRIANGLE_MST, actual);
+    assertGraphEquals(TRIANGLE_MST, actual);
   }
 
   @Test
@@ -56,7 +58,7 @@ public final class TspOptimizerTest {
     // Generate the MST of the TRIANGLE graph starting at vertex B
 
     HashMap<Attraction, ArrayList<Edge>> actual = TspOptimizer.getMst(B, TRIANGLE);
-    checkGraphEquals(TRIANGLE_MST, actual);
+    assertGraphEquals(TRIANGLE_MST, actual);
   }
 
   @Test
@@ -64,7 +66,7 @@ public final class TspOptimizerTest {
     // Generate the MST of the K4 graph starting at vertex A
 
     HashMap<Attraction, ArrayList<Edge>> actual = TspOptimizer.getMst(A, K4);
-    checkGraphEquals(K4_MST, actual);
+    assertGraphEquals(K4_MST, actual);
   }
 
   @Test
@@ -72,7 +74,7 @@ public final class TspOptimizerTest {
     // Generate the MST of the K4 graph starting at vertex C
 
     HashMap<Attraction, ArrayList<Edge>> actual = TspOptimizer.getMst(C, K4);
-    checkGraphEquals(K4_MST, actual);
+    assertGraphEquals(K4_MST, actual);
   }
 
   @Test
@@ -82,11 +84,11 @@ public final class TspOptimizerTest {
     ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(A, B, C));
     ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(A, C, B));
     ArrayList<Attraction> actual = TspOptimizer.dfs(A, TRIANGLE_MST);
-    Assert.assertTrue(expected1.equals(actual) || expected2.equals(actual));
+    assertThat(Arrays.asList(expected1, expected2), hasItem(actual));
   }
 
   @Test
-  public void K4_TRIANGLE_MST() {
+  public void dfs_K4_MST() {
     // Generate the dfs ordering of K4_MST graph.
     // Start at vertex A so there is a unique DFS traversal.
 
@@ -96,41 +98,39 @@ public final class TspOptimizerTest {
   }
 
   @Test
-  @Ignore
   public void optimize_TRIANGLE_pickRandomSourceAttraction() {
     // Use triangle graph. Choose a random Attraction as source.
-    // Algorithm should return a path with the two shortest edges A--B--C.
+    // Algorithm should return a path with the two shortest edges B--A--C or C--A--B.
 
-    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C));
+    ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(B, A, C));
+    ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(C, A, B));
     ArrayList<Attraction> actual = TspOptimizer.optimize(TRIANGLE);
-    Assert.assertEquals(expected, actual);
+    assertThat(Arrays.asList(expected1, expected2), hasItem(actual));
   }
 
   @Test
-  @Ignore
   public void optimize_TRIANGLE_DFSOptimalPath() {
     // Use triangle graph. DFS traversal of MST is the optimal path.
-    // Algorithm should return a path with the two shortest edges A--B--C.
+    // Algorithm should return a path with the two shortest edges B--A--C.
 
-    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C));
-    ArrayList<Attraction> actual = TspOptimizer.optimize(A, TRIANGLE);
-    Assert.assertEquals(expected, actual);
-  }
-
-  @Test
-  @Ignore
-  public void optimize_TRIANGLE_deleteEdgeForOptimalPath() {
-    // Use triangle graph. DFS traversal of MST is not the optimal path, optimal path requires
-    // deletion of heaviest edge in cycle. Algorithm should return a path with the two shortest
-    // edges A--B--C.
-
-    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C));
+    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(B, A, C));
     ArrayList<Attraction> actual = TspOptimizer.optimize(B, TRIANGLE);
     Assert.assertEquals(expected, actual);
   }
 
   @Test
-  @Ignore
+  public void optimize_TRIANGLE_deleteEdgeForOptimalPath() {
+    // Use triangle graph. DFS traversal of MST is not the optimal path, optimal path requires
+    // deletion of heaviest edge in cycle. Algorithm should return a path with the two shortest
+    // edges B--A--C or C--A--B.
+
+    ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(B, A, C));
+    ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(C, A, B));
+    ArrayList<Attraction> actual = TspOptimizer.optimize(A, TRIANGLE);
+    assertThat(Arrays.asList(expected1, expected2), hasItem(actual));
+  }
+
+  @Test
   public void optimize_K4_findDFSOptimalPath() {
     // Create complete graph with 4 vertices. DFS traversal of MST is the optimal path.
     // Algorithm should return a path with three shortest edges A--B--C--D.
@@ -141,19 +141,20 @@ public final class TspOptimizerTest {
   }
 
   @Test
-  @Ignore
   public void optimize_K4_possiblyFindSuboptimalApproximation() {
     // Create complete graph with 4 vertices. DFS traversal of MST is not the optimal path.
     // Algorithm should return a path 6/5 times length of optimal path C--D--B--A
     // or the optimal path A--B--C--D.
 
-    ArrayList<Attraction> expectedOptimal = new ArrayList<>(Arrays.asList(A, B, C, D));
-    ArrayList<Attraction> expectedSuboptimal = new ArrayList<>(Arrays.asList(C, D, B, A));
+    ArrayList<Attraction> expectedOptimal1 = new ArrayList<>(Arrays.asList(A, B, C, D));
+    ArrayList<Attraction> expectedOptimal2 = new ArrayList<>(Arrays.asList(D, C, B, A));
+    ArrayList<Attraction> expectedSuboptimal1 = new ArrayList<>(Arrays.asList(C, D, B, A));
+    ArrayList<Attraction> expectedSuboptimal2 = new ArrayList<>(Arrays.asList(A, B, D, C));
     ArrayList<Attraction> actual = TspOptimizer.optimize(C, K4);
-    Assert.assertTrue(expectedOptimal.equals(actual) || expectedSuboptimal.equals(actual));
+    assertThat(Arrays.asList(expectedOptimal1, expectedOptimal2, expectedSuboptimal1, expectedSuboptimal2), hasItem(actual));
   }
 
-  private void checkGraphEquals(
+  private void assertGraphEquals(
       HashMap<Attraction, ArrayList<Edge>> expected, HashMap<Attraction, ArrayList<Edge>> actual) {
     for (Attraction a : expected.keySet()) {
       ArrayList<Edge> expectedEdges = expected.get(a);

--- a/backend/src/test/java/com/google/sps/TspOptimizerTest.java
+++ b/backend/src/test/java/com/google/sps/TspOptimizerTest.java
@@ -38,7 +38,7 @@ public final class TspOptimizerTest {
   // Straight forward triangle graph
   private static final HashMap<Attraction, ArrayList<Edge>> TRIANGLE = create_TRIANGLE();
   private static final HashMap<Attraction, ArrayList<Edge>> TRIANGLE_MST = create_TRIANGLE_MST();
-  
+
   // Complete graph with 4 vertices that has a single optimal solution
   private static final HashMap<Attraction, ArrayList<Edge>> K4 = create_K4();
   private static final HashMap<Attraction, ArrayList<Edge>> K4_MST = create_K4_MST();
@@ -76,14 +76,23 @@ public final class TspOptimizerTest {
   }
 
   @Test
-  @Ignore
-  public void dfs_TRIANGLE() {
-    // Generate the MST of the TRIANGLE graph
+  public void dfs_TRIANGLE_MST() {
+    // Generate the dfs ordering of TRIANGLE_MST graph
 
     ArrayList<Attraction> expected1 = new ArrayList<>(Arrays.asList(A, B, C));
     ArrayList<Attraction> expected2 = new ArrayList<>(Arrays.asList(A, C, B));
     ArrayList<Attraction> actual = TspOptimizer.dfs(A, TRIANGLE_MST);
     Assert.assertTrue(expected1.equals(actual) || expected2.equals(actual));
+  }
+
+  @Test
+  public void K4_TRIANGLE_MST() {
+    // Generate the dfs ordering of K4_MST graph.
+    // Start at vertex A so there is a unique DFS traversal.
+
+    ArrayList<Attraction> expected = new ArrayList<>(Arrays.asList(A, B, C, D));
+    ArrayList<Attraction> actual = TspOptimizer.dfs(A, K4_MST);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test


### PR DESCRIPTION
Implement `optimize` functionality of TSP approximation. Add/edit Junit tests for `optimize` functions.

- `optimize(source, graph)` runs the TSP algorithm from a specified source
- `optimize(graph)` uses the first vertex in the graph HashMap keySet as `source` and then calls `optimize(source, graph)`
- implement helper function `getOptimalOrdering`
  - removes the heaviest edge from the dfs ordering to produce an optimized ordering

Pseudocode for optimize (with source):
```
mst <-- getMst(source, graph) 
dfsOrder <-- dfs pre-order of mst starting at source
find where the heaviest edge is in the dfsOrder cycle, 
    where the last attraction has an edge to first attraction (i.e: A-B-C-D-A)
startIndex <-- index of attraction to start trip route (index of attraction after heaviest edge)
return ArrayList<Attraction> of (startIndex)--(lastAttraction)--(firstAttraction)--(startIndex - 1)
``` 

Before: 
![image](https://user-images.githubusercontent.com/19807230/87093479-1e21cf00-c1f2-11ea-8885-fd67a4aca897.png)

After: 
![image](https://user-images.githubusercontent.com/19807230/87093445-0f3b1c80-c1f2-11ea-9f61-c8087cea81be.png)
