### PR TITLE
Add checkmark, Explore Page css

### DIFF
--- a/frontend/src/ExploreView.js
+++ b/frontend/src/ExploreView.js
@@ -1,12 +1,17 @@
 import React, { useState } from 'react';
-import Card from 'react-bootstrap/Card';
-import styles from './ExploreView.module.css';
-import Button from 'react-bootstrap/Button';
-import Map from './map/Map';
 import { useLocation, useHistory } from 'react-router-dom';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getQueryParameters } from './parameterUtils.js';
+
+import Card from 'react-bootstrap/Card';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+import styles from './ExploreView.module.css';
+
+import Map from './map/Map';
 
 /**
  * Explore view with selectable attraction images and map
@@ -76,54 +81,59 @@ function Explore() {
   };
 
   return (
-    <div className={styles.exploreContainer}>
-      <div className={styles.attractionsSection}>
-        <div className={styles.attractionImagesContainer}>
-          {initialAttractions.length === 0 ? (
-            <div className={styles.fillerText}>
-              {loading ? 'Loading . . .' : 'No Images Found'}
-            </div>
-          ) : (
-            initialAttractions.map((attraction, index) => (
-              <Card
-                className={`${styles.attractionContainer} ${
-                  attraction.selected ? styles.selectedImage : ''
-                }`}
-                onClick={() => toggleSelection(attraction)}
-                key={index}
-              >
-                <Card.Img
-                  src={attraction.photoUrl}
-                  className={styles.attraction}
-                  alt="attraction image"
-                />
-                <Card.ImgOverlay className={styles.overlay}></Card.ImgOverlay>
-                <Card.ImgOverlay>{attraction.selected && (
-                  <FontAwesomeIcon icon={faCheck} className={styles.check} />
-                )}</Card.ImgOverlay>
-              </Card>
-            ))
-          )}
-        </div>
-
-        <Button
-          className={styles.routeButton}
-          onClick={() => handleRouting(history)}
-          variant="primary"
-          disabled={selectedAttractions.length < 1}
-        >
-          Show Route
-        </Button>
-      </div>
-      <Map
-        className={styles.mapContainer}
-        onReady={onMapReady}
-        attractions={selectedAttractions}
-        mode="pins"
-        centerLocation={tripObject.centerLocation}
-        key={selectedAttractions}
-      />
-    </div>
+    <Container className={styles.exploreContainer}>
+      <Row>
+        <Col sm={6}>
+          <div className={styles.attractionImagesContainer}>
+            {initialAttractions.length === 0 ? (
+              <div className={styles.fillerText}>
+                {loading ? 'Loading . . .' : 'No Images Found'}
+              </div>
+            ) : (
+              initialAttractions.map((attraction, index) => (
+                <Card
+                  className={`${styles.attractionContainer} ${
+                    attraction.selected ? styles.selectedImage : ''
+                  }`}
+                  onClick={() => toggleSelection(attraction)}
+                  key={index}
+                >
+                  <Card.Img
+                    src={attraction.photoUrl}
+                    className={styles.attraction}
+                    alt="attraction image"
+                  />
+                  <Card.ImgOverlay className={styles.overlay}></Card.ImgOverlay>
+                  <Card.ImgOverlay>
+                    {attraction.selected && (
+                      <FontAwesomeIcon icon={faCheck} className={styles.check} />
+                    )}
+                  </Card.ImgOverlay>
+                </Card>
+              ))
+            )}
+          </div>
+          <Button
+            className={styles.routeButton}
+            onClick={() => handleRouting(history)}
+            variant="primary"
+            disabled={selectedAttractions.length < 1}
+          >
+            Show Route
+          </Button>
+        </Col>
+        <Col sm={6}>
+          <Map
+            className={styles.mapContainer}
+            onReady={onMapReady}
+            attractions={selectedAttractions}
+            mode="pins"
+            centerLocation={tripObject.centerLocation}
+            key={selectedAttractions}
+          />
+        </Col>
+      </Row>
+    </Container>
   );
 
   /**

--- a/frontend/src/ExploreView.js
+++ b/frontend/src/ExploreView.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Card from 'react-bootstrap/Card';
 import styles from './ExploreView.module.css';
 import Button from 'react-bootstrap/Button';
 import Map from './map/Map';
@@ -84,22 +85,23 @@ function Explore() {
             </div>
           ) : (
             initialAttractions.map((attraction, index) => (
-              <div className={styles.attractionContainer} onClick={() => toggleSelection(attraction)} key={index}>
-                <img
-                  
-                  className={`${styles.attraction} ${
-                    attraction.selected ? styles.selectedImage : ''
-                  }`}
+              <Card
+                className={`${styles.attractionContainer} ${
+                  attraction.selected ? styles.selectedImage : ''
+                }`}
+                onClick={() => toggleSelection(attraction)}
+                key={index}
+              >
+                <Card.Img
                   src={attraction.photoUrl}
-                  alt=""
+                  className={styles.attraction}
+                  alt="attraction image"
                 />
-                {attraction.selected && (
-                  <FontAwesomeIcon
-                    icon={faCheck}
-                    className={styles.check}
-                  />
-                )}
-              </div>
+                <Card.ImgOverlay className={styles.overlay}></Card.ImgOverlay>
+                <Card.ImgOverlay>{attraction.selected && (
+                  <FontAwesomeIcon icon={faCheck} className={styles.check} />
+                )}</Card.ImgOverlay>
+              </Card>
             ))
           )}
         </div>

--- a/frontend/src/ExploreView.module.css
+++ b/frontend/src/ExploreView.module.css
@@ -3,7 +3,11 @@
 }
 
 .attractionContainer {
-  position: relative;
+  margin: 10px;
+}
+
+.attractionContainer:hover {
+  cursor: pointer;
 }
 
 .attractionsSection {
@@ -22,32 +26,15 @@
 
 .attraction {
   height: 300px;
-  margin: 10px;
-  width: 300px;
   object-fit: cover;
-}
-
-.attraction:hover {
-  cursor: pointer;
-  /* opacity: 0.5; */
+  width: 300px;
 }
 
 .check {
-  color: white;
-  font-size: 80px;
-  left: 120px;
+  color: whitesmoke;
+  font-size: 56px;
+  margin: 40%;
   opacity: 0.8;
-  position: absolute;
-  top: 120px;
-}
-
-.selectedImage {
-  background-color: #303030;
-  opacity: 0.55;
-}
-
-.selectedImage:hover {
-  opacity: 0.65;
 }
 
 .mapContainer {
@@ -66,4 +53,17 @@
 
 .fillerText {
   margin: auto;
+}
+
+.overlay {
+  background-color: #303030;
+  opacity: 0;
+}
+
+.attractionContainer:hover .overlay {
+  opacity: 0.3;
+}
+
+.selectedImage .overlay {
+  opacity: 0.4;
 }

--- a/frontend/src/ExploreView.module.css
+++ b/frontend/src/ExploreView.module.css
@@ -1,5 +1,5 @@
 .exploreContainer {
-  display: flex;
+  max-width: 2000px;
 }
 
 .attractionContainer {
@@ -8,12 +8,6 @@
 
 .attractionContainer:hover {
   cursor: pointer;
-}
-
-.attractionsSection {
-  display: flex;
-  flex-direction: column;
-  width: 1000px;
 }
 
 .attractionImagesContainer {
@@ -35,11 +29,6 @@
   font-size: 56px;
   margin: 40%;
   opacity: 0.8;
-}
-
-.mapContainer {
-  margin-right: 100px;
-  margin-top: 30px;
 }
 
 .routeButton {

--- a/frontend/src/map/Map.js
+++ b/frontend/src/map/Map.js
@@ -45,7 +45,6 @@ function Map({ attractions, mode, centerLocation, google, onReady, view }) {
   if (mode === 'pins') {
     return (
       <GoogleMap
-        className={styles.mapContainer}
         google={google}
         onReady={onPinsReady}
         center={centerLocation}
@@ -63,14 +62,12 @@ function Map({ attractions, mode, centerLocation, google, onReady, view }) {
   const waypointsParam = waypoints.length > 0 ? `waypoints=${waypoints.join('|')}` : '';
 
   return (
-    <div className={styles.mapContainer}>
-      <iframe
-        className={styles.map}
-        title="trip-map"
-        src={`${MAPS_EMBED_URL}?key=${MAPS_API_KEY}&origin=${origin}&destination=${destination}&${waypointsParam}`}
-        allowFullScreen
-      ></iframe>
-    </div>
+    <iframe
+      className={styles.map}
+      title="trip-map"
+      src={`${MAPS_EMBED_URL}?key=${MAPS_API_KEY}&origin=${origin}&destination=${destination}&${waypointsParam}`}
+      allowFullScreen
+    ></iframe>
   );
 }
 

--- a/frontend/src/map/Map.module.css
+++ b/frontend/src/map/Map.module.css
@@ -1,9 +1,4 @@
-.mapContainer {
-  margin: 10px;
-}
-
-.map,
-.mapContainer {
+.map {
   border: 0;
   height: 80vh;
   width: 42rem;


### PR DESCRIPTION
Add checkmarks to images when selected and center Explore page.

- refactor each image into a bootstrap `Card`
- add a Card overlay that increases in opacity on hover and when image is selected 
- center `ExploreView` with bootstap `Container`, `Row`, `Col`
  - remove `mapContainer` styles
  - only looks nice when viewed on monitor, not responsive so far 

![image](https://user-images.githubusercontent.com/19807230/87464821-9c9eb800-c5c8-11ea-9993-59eaad47fc7f.png)
