### PR TITLE
fix attractions bug

### DIFF
--- a/frontend/src/ExploreView.js
+++ b/frontend/src/ExploreView.js
@@ -52,7 +52,7 @@ function Explore() {
         placesService.nearbySearch(
           {
             location: coordinates,
-            radius: 8000,
+            radius: 10000,
           },
           handleNearbySearch
         );
@@ -80,6 +80,7 @@ function Explore() {
     );
   };
 
+  console.log(initialAttractions);
   return (
     <Container className={styles.exploreContainer}>
       <Row>

--- a/frontend/src/ExploreView.module.css
+++ b/frontend/src/ExploreView.module.css
@@ -3,6 +3,7 @@
 }
 
 .attractionContainer {
+  height: 300px;
   margin: 10px;
 }
 


### PR DESCRIPTION
Change css of `Card` to match the 300px height of attraction images, and increase search radius to 10000 meters. There is a bug that sometimes only two attraction images would load for a search like "Paris" or "London". I was able to fix the css, but not the search results.

bug: 
![image](https://user-images.githubusercontent.com/19807230/87486828-ffa44500-c5f0-11ea-8613-945ed9ff8d67.png)

fix: 
![image](https://user-images.githubusercontent.com/19807230/87486861-19458c80-c5f1-11ea-9826-4e8d358e81af.png)


