### PR TITLE
push to history route changes, move handleRouting function

### DIFF
--- a/frontend/src/ExploreView.js
+++ b/frontend/src/ExploreView.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getQueryParameters } from './parameterUtils.js';
+import { getQueryParameters, handleRouting } from './routingUtils.js';
 
 import Card from 'react-bootstrap/Card';
 import Container from 'react-bootstrap/Container';
@@ -115,7 +115,9 @@ function Explore() {
           </div>
           <Button
             className={styles.routeButton}
-            onClick={() => handleRouting(history)}
+            onClick={() =>
+              handleRouting(history, 'route', tripObject, selectedAttractions)
+            }
             variant="primary"
             disabled={selectedAttractions.length < 1}
           >
@@ -135,16 +137,6 @@ function Explore() {
       </Row>
     </Container>
   );
-
-  /**
-   * Creates route url and navigates to /route?trip=
-   * @param {object} history used to route dom with react
-   */
-  function handleRouting(history) {
-    tripObject.selectedAttractions = selectedAttractions;
-    const routeUrl = '?trip=' + encodeURIComponent(JSON.stringify(tripObject));
-    history.push(`/route${routeUrl}`);
-  }
 
   /**
    * changes selection property of attraction which causes the following

--- a/frontend/src/RouteView.js
+++ b/frontend/src/RouteView.js
@@ -8,13 +8,14 @@ import Modal from 'react-bootstrap/Modal';
 import styles from './RouteView.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClone } from '@fortawesome/free-solid-svg-icons';
+import { getQueryParameters, handleRouting } from './routingUtils.js';
 
 import Map from './map/Map.js';
 import Route from './route/Route.js';
 import OptimizeButton from './route/OptimizeButton.js';
 import SaveShareButtons from './route/SaveShareButtons.js';
 import TripName from './trip-name/TripName.js';
-import { getQueryParameters } from './parameterUtils.js';
+
 /**
  * Render the route page with list of locations in order and directions on a map between the locations.
  */
@@ -57,24 +58,18 @@ function RouteView({ loggedIn }) {
     // save to back end database
   }
 
-  function onManualPlaceChange() {
+  function onManualPlaceChange(newAttractions) {
+    setAttractions(newAttractions);
     setIsOptimized(false);
     setIsSaved(false);
+    tripObject.selectedAttractions = newAttractions;
+    const url = '?trip=' + encodeURIComponent(JSON.stringify(tripObject));
+    history.push(`/route${url}`);
   }
 
   function copyToClipboard(e) {
     textAreaRef.current.select();
     document.execCommand('copy');
-  }
-
-  /**
-   * Creates url and navigates to /explore?trip=
-   * @param {object} history used to route dom with react
-   */
-  function handleRouting(history) {
-    tripObject.selectedAttractions = attractions;
-    const url = '?trip=' + encodeURIComponent(JSON.stringify(tripObject));
-    history.push(`/explore${url}`);
   }
 
   return (
@@ -113,7 +108,7 @@ function RouteView({ loggedIn }) {
       <Button
         variant="link"
         className={styles.editButton}
-        onClick={() => handleRouting(history)}
+        onClick={() => handleRouting(history, 'explore', tripObject, attractions)}
       >
         Edit Attractions
       </Button>
@@ -127,11 +122,7 @@ function RouteView({ loggedIn }) {
         <Row>
           <Col>
             <Row className={styles.routeListContainer}>
-              <Route
-                places={attractions}
-                setPlaces={setAttractions}
-                onManualPlaceChange={onManualPlaceChange}
-              />
+              <Route places={attractions} onManualPlaceChange={onManualPlaceChange} />
             </Row>
             <Row>
               <Container>

--- a/frontend/src/RouteView.js
+++ b/frontend/src/RouteView.js
@@ -62,9 +62,7 @@ function RouteView({ loggedIn }) {
     setAttractions(newAttractions);
     setIsOptimized(false);
     setIsSaved(false);
-    tripObject.selectedAttractions = newAttractions;
-    const url = '?trip=' + encodeURIComponent(JSON.stringify(tripObject));
-    history.push(`/route${url}`);
+    handleRouting(history, 'route', tripObject, newAttractions);
   }
 
   function copyToClipboard(e) {

--- a/frontend/src/parameterUtils.js
+++ b/frontend/src/parameterUtils.js
@@ -1,9 +1,0 @@
-/**
- * Extract the url parameters and convert to dictionary
- * @param {string} query url string
- * @return {object} key value pair of url parameters
- */
-export const getQueryParameters = (query) => {
-  const params = query.split('?')[1];
-  return Object.fromEntries(new URLSearchParams(params));
-};

--- a/frontend/src/route/Route.js
+++ b/frontend/src/route/Route.js
@@ -6,7 +6,7 @@ import { DragDropContext, Droppable } from 'react-beautiful-dnd';
  * Return locations listed in order of the user's planned route.
  * Route list is customizable via drag and drop (docs: https://github.com/atlassian/react-beautiful-dnd)
  */
-function Route({ places, setPlaces, onManualPlaceChange }) {
+function Route({ places, onManualPlaceChange }) {
   // referece: https://egghead.io/lessons/react-persist-list-reordering-with-react-beautiful-dnd-using-the-ondragend-callback
   function handleOnDragEnd({ destination, source, draggableId }) {
     // no change in list ordering due after drag
@@ -25,8 +25,7 @@ function Route({ places, setPlaces, onManualPlaceChange }) {
     const newPlaces = Array.from(places);
     newPlaces.splice(source.index, 1);
     newPlaces.splice(destination.index, 0, places[source.index]);
-    setPlaces(newPlaces);
-    onManualPlaceChange();
+    onManualPlaceChange(newPlaces);
   }
 
   // ref: https://egghead.io/lessons/react-reorder-a-list-with-react-beautiful-dnd

--- a/frontend/src/routingUtils.js
+++ b/frontend/src/routingUtils.js
@@ -9,8 +9,11 @@ export const getQueryParameters = (query) => {
 };
 
 /**
- * Creates url and navigates to /explore?trip=
+ * Creates url and navigates to /{page}?trip=
  * @param {object} history used to route dom with react
+ * @param {string} page the page to which to route (explore|route)
+ * @param {object} tripObject json object that contains trip information
+ * @param {object} attractions list of selected attractions
  */
 export const handleRouting = (history, page, tripObject, attractions) => {
   tripObject.selectedAttractions = attractions;

--- a/frontend/src/routingUtils.js
+++ b/frontend/src/routingUtils.js
@@ -1,0 +1,19 @@
+/**
+ * Extract the url parameters and convert to dictionary
+ * @param {string} query url string
+ * @return {object} key value pair of url parameters
+ */
+export const getQueryParameters = (query) => {
+  const params = query.split('?')[1];
+  return Object.fromEntries(new URLSearchParams(params));
+};
+
+/**
+ * Creates url and navigates to /explore?trip=
+ * @param {object} history used to route dom with react
+ */
+export const handleRouting = (history, page, tripObject, attractions) => {
+  tripObject.selectedAttractions = attractions;
+  const url = '?trip=' + encodeURIComponent(JSON.stringify(tripObject));
+  history.push(`/${page}${url}`);
+};


### PR DESCRIPTION
- push to history the new route order every time it's manually updated
  - sharing link now shows the same route order
- move `setAttractions` to `onManualPlaceChange` function in `RouteView` to avoid passing another prop to `Route`
- move `handleRouting` function in `ExploreView` and `RouteView` to `routingUtils.js` (renamed from `parameterUtils.js`)
  - add parameter `page` to indicate whether to route to `/explore` or `/route`
  - add parameter `attractions` for selected attractions, `tripObject` for the current trip object 