### PR TITLE
intuitive trip name

### DIFF
--- a/frontend/src/trip-name/TripName.js
+++ b/frontend/src/trip-name/TripName.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import Form from 'react-bootstrap/Form';
 import InputGroup from 'react-bootstrap/InputGroup';
 import Container from 'react-bootstrap/Container';
-import Row from 'react-bootstrap/Row';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 import styles from './TripName.module.css';
@@ -15,7 +14,8 @@ function TripName({ tripName }) {
   const [isEditing, setIsEditing] = useState(false);
   const [name, setName] = useState(tripName || '');
 
-  function handleSave() {
+  function handleSave(e) {
+    e.preventDefault();
     setIsEditing(false);
     // send to back end
   }
@@ -28,31 +28,30 @@ function TripName({ tripName }) {
     <Container
       className={`${styles.tripNameContainer} ${isEditing ? styles.edit : ''}`}
     >
-      <Row>
-        <Form noValidate onClick={() => setIsEditing(true)}>
-          <Form.Group>
-            <InputGroup>
-              <InputGroup.Prepend className={styles.editIcon}>
-                <FontAwesomeIcon icon={faPencilAlt} />
-              </InputGroup.Prepend>
-              <Form.Control
-                type="text"
-                placeholder="Trip Name"
-                defaultValue={name}
-                aria-describedby="inputGroupPrepend"
-                className={styles.tripNameInput}
-                onChange={handleChange}
-                required
-              />
-            </InputGroup>
-          </Form.Group>
-        </Form>
-      </Row>
-      <Row className={styles.saveRow}>
-        <div className={styles.saveBtn} onClick={handleSave}>
-          Save
-        </div>
-      </Row>
+      <Form
+        noValidate
+        onClick={() => setIsEditing(true)}
+        className={styles.form}
+        onSubmit={handleSave}
+      >
+        <Form.Group>
+          <InputGroup>
+            <InputGroup.Prepend className={styles.editIcon}>
+              <FontAwesomeIcon icon={faPencilAlt} />
+            </InputGroup.Prepend>
+            <Form.Control
+              type="text"
+              placeholder="Trip Name"
+              defaultValue={name}
+              aria-describedby="inputGroupPrepend"
+              className={styles.tripNameInput}
+              onChange={handleChange}
+              onBlur={handleSave}
+              required
+            />
+          </InputGroup>
+        </Form.Group>
+      </Form>
     </Container>
   );
 }

--- a/frontend/src/trip-name/TripName.module.css
+++ b/frontend/src/trip-name/TripName.module.css
@@ -10,7 +10,7 @@
 .tripNameInput {
   border: none;
   font-size: 1.5rem;
-  padding: 2px 4px;
+  padding: 1px 4px;
 }
 
 .tripNameInput:focus,
@@ -36,7 +36,7 @@
   color: var(--gray);
   display: none;
   font-size: 0.9rem;
-  margin: 12px auto;
+  margin: 4px auto;
   text-decoration: underline;
 }
 
@@ -49,9 +49,15 @@
   margin-bottom: 4px;
 }
 
+.form ::placeholder {
+  color: #949494;
+  font-style: italic;
+}
+
 /* styles for when trip name is being edited */
 
-.edit .editIcon {
+.edit .editIcon,
+.form:hover .editIcon {
   color: var(--blue);
   opacity: 1;
 }


### PR DESCRIPTION
Make editing the trip name more intuitive.

- save on enter or when user clicks away from input 
- remove save text that used to be at the bottom

default:
![image](https://user-images.githubusercontent.com/19807230/87717723-b6c1cd00-c765-11ea-8d9a-8d4eed730809.png)
editing:
![image](https://user-images.githubusercontent.com/19807230/87717759-c9d49d00-c765-11ea-82d9-1710f40f9d23.png)
