### PR TITLE
Route View CSS

### DIFF
--- a/frontend/src/ExploreView.js
+++ b/frontend/src/ExploreView.js
@@ -36,7 +36,6 @@ function Explore() {
     tripObject.selectedAttractions
   );
   const [initialAttractions, setInitialAttractions] = useState([]);
-  const [pagination, setPagination] = useState(null)
   const history = useHistory();
 
   const onMapReady = (google, map) => {
@@ -80,7 +79,6 @@ function Explore() {
       },
       handleTextSearch
     );
-    setPagination(new google.maps.places.PlaceSearchPagination(map));
   };
 
   return (

--- a/frontend/src/ExploreView.js
+++ b/frontend/src/ExploreView.js
@@ -36,6 +36,7 @@ function Explore() {
     tripObject.selectedAttractions
   );
   const [initialAttractions, setInitialAttractions] = useState([]);
+  const [pagination, setPagination] = useState(null)
   const history = useHistory();
 
   const onMapReady = (google, map) => {
@@ -79,6 +80,7 @@ function Explore() {
       },
       handleTextSearch
     );
+    setPagination(new google.maps.places.PlaceSearchPagination(map));
   };
 
   return (

--- a/frontend/src/RouteView.js
+++ b/frontend/src/RouteView.js
@@ -114,10 +114,10 @@ function RouteView({ loggedIn }) {
       )}
       <div className={styles.container}>
         <Row className={styles.row}>
-          <TripName />
-        </Row>
-        <Row className={styles.row}>
           <Col sm={4}>
+            <Row className={styles.row}>
+              <TripName />
+            </Row>
             <Row className={styles.routeListContainer}>
               <Route places={attractions} onManualPlaceChange={onManualPlaceChange} />
             </Row>

--- a/frontend/src/RouteView.module.css
+++ b/frontend/src/RouteView.module.css
@@ -54,6 +54,8 @@
 }
 
 .container {
+  margin: auto;
+  max-width: 2000px;
   width: 100%;
 }
 

--- a/frontend/src/map/Map.js
+++ b/frontend/src/map/Map.js
@@ -31,7 +31,6 @@ function Map({ attractions, mode, centerLocation, google, onReady, view }) {
         const content = `
           <div>
             <h4 class=${styles.infoWindowName}>${attraction.name}</h4>
-            <div class=${styles.infoWindowDescription}>Short description of attraction if desired</div>
             <div>
               <img class=${styles.infoWindowImg} src="${attraction.photoUrl}" alt="${attraction.name} Image" />
             </div>
@@ -66,7 +65,7 @@ function Map({ attractions, mode, centerLocation, google, onReady, view }) {
     <iframe
       className={styles.map}
       title="trip-map"
-      src={`${MAPS_EMBED_URL}?key=${MAPS_API_KEY}&origin=${origin}&destination=${destination}&${waypointsParam}`}
+      src={`${MAPS_EMBED_URL}?key=${MAPS_API_KEY}&origin=${origin}&destination=${destination}&${waypointsParam}&zoom=13`}
       allowFullScreen
     ></iframe>
   );

--- a/frontend/src/map/Map.module.css
+++ b/frontend/src/map/Map.module.css
@@ -1,6 +1,7 @@
 .map {
   border: 0;
   height: 85vh;
+  margin-top: 14px;
   width: 100%;
 }
 

--- a/frontend/src/map/Map.module.css
+++ b/frontend/src/map/Map.module.css
@@ -1,6 +1,6 @@
 .map {
   border: 0;
-  height: 70vh;
+  height: 85vh;
   width: 100%;
 }
 
@@ -8,10 +8,13 @@
   color: #383838;
 }
 
-.infoWindowDescription {
-  margin-bottom: 10px;
-}
-
 .infoWindowImg {
   height: 200px;
+}
+
+/* Medium devices */
+@media (max-width: 1600px) {
+  .infoWindowName {
+    font-size: 1.2rem;
+  }
 }

--- a/frontend/src/route/LocationCard.js
+++ b/frontend/src/route/LocationCard.js
@@ -32,7 +32,7 @@ function LocationCard({ location, description, image, index }) {
                 <Card.Img src={image} className={styles.locationImg} alt="Card image" />
                 <Card.ImgOverlay className={styles.overlay}></Card.ImgOverlay>
                 <Card.ImgOverlay>
-                  <Card.Title>{location}</Card.Title>
+                  <Card.Title className={styles.locationName}>{location}</Card.Title>
                 </Card.ImgOverlay>
               </Card>
             </Col>

--- a/frontend/src/route/LocationCard.module.css
+++ b/frontend/src/route/LocationCard.module.css
@@ -5,7 +5,7 @@
 
 .locationCard,
 .locationImg {
-  height: 22vh;
+  height: 230px;
   object-fit: cover;
 }
 
@@ -28,4 +28,20 @@
 
 .locationCardContainer:hover .arrows {
   opacity: 0.6;
+}
+
+.locationName {
+  margin-top: 6%;
+}
+
+/* Medium devices */
+@media (max-width: 1600px) {
+  .locationCard,
+  .locationImg {
+    height: 22vh;
+  }
+
+  .locationName {
+    font-size: 1.2rem;
+  }
 }


### PR DESCRIPTION
Make the route view more responsive between chromebook and monitor screen sizes. Move `TripName` above the list of routes. 

![image](https://user-images.githubusercontent.com/19807230/88080486-015f9280-cb34-11ea-8905-7a67bd29680a.png)
